### PR TITLE
// -------------------------- Change Log -------------------------- //

### DIFF
--- a/editor/editor.cxx
+++ b/editor/editor.cxx
@@ -27,10 +27,41 @@
 //     http://www.fltk.org/str.php
 //
 
+// -------------------------- Change Log -------------------------- //
+// Ver 0.2 1/21/2025
+// Changed by: Rich for Tinycore Linux.
+// Removed syntax highlighting.
+// Disabled "drag and drop text". You can re-enable it with  ~/.Xdefaults:
+//        fltk*dndTextOps: true
+// Added version number to source.
+// Added Version menu entry.
+// Added line number and line wrap code lifted from a later version of this program.
+// I added these options in preprocessor directives:
+//     Uncomment #define DIS_DNDTEXT to disable drag and drop text.
+//     Uncomment #define ENA_LINEWRAP to enable line wrapping in Edit menu.
+//     Uncomment #define ENA_LINENUMS to enable line numbers in Edit menu.
+//
+// --------------------------- End Log ---------------------------- //
+
+#define Version "Ver 0.2 1/21/2025"
+
+// Uncomment the next line to disable drag and drop text.
+#define DIS_DNDTEXT
+
+// Uncomment the next line to enable linewrap option in Edit menu.
+#define ENA_LINEWRAP
+
+// Uncomment the next line to enable linenumber option in Edit menu.
+#define ENA_LINENUMS
+
+#ifdef ENA_LINENUMS
+// Width of line number display, if enabled.
+const int line_num_width = 40;
+#endif // ENA_LINENUMS
+
 //
 // Include necessary headers...
 //
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -60,364 +91,6 @@ char               title[256];
 Fl_Text_Buffer     *textbuf = 0;
 
 
-// Syntax highlighting stuff...
-Fl_Text_Buffer     *stylebuf = 0;
-Fl_Text_Display::Style_Table_Entry
-                   styletable[] = {	// Style table
-		     { FL_BLACK,      FL_COURIER,        14 }, // A - Plain
-		     { FL_DARK_GREEN, FL_COURIER_ITALIC, 14 }, // B - Line comments
-		     { FL_DARK_GREEN, FL_COURIER_ITALIC, 14 }, // C - Block comments
-		     { FL_BLUE,       FL_COURIER,        14 }, // D - Strings
-		     { FL_DARK_RED,   FL_COURIER,        14 }, // E - Directives
-		     { FL_DARK_RED,   FL_COURIER_BOLD,   14 }, // F - Types
-		     { FL_BLUE,       FL_COURIER_BOLD,   14 }  // G - Keywords
-		   };
-const char         *code_keywords[] = {	// List of known C/C++ keywords...
-		     "and",
-		     "and_eq",
-		     "asm",
-		     "bitand",
-		     "bitor",
-		     "break",
-		     "case",
-		     "catch",
-		     "compl",
-		     "continue",
-		     "default",
-		     "delete",
-		     "do",
-		     "else",
-		     "false",
-		     "for",
-		     "goto",
-		     "if",
-		     "new",
-		     "not",
-		     "not_eq",
-		     "operator",
-		     "or",
-		     "or_eq",
-		     "return",
-		     "switch",
-		     "template",
-		     "this",
-		     "throw",
-		     "true",
-		     "try",
-		     "while",
-		     "xor",
-		     "xor_eq"
-		   };
-const char         *code_types[] = {	// List of known C/C++ types...
-		     "auto",
-		     "bool",
-		     "char",
-		     "class",
-		     "const",
-		     "const_cast",
-		     "double",
-		     "dynamic_cast",
-		     "enum",
-		     "explicit",
-		     "extern",
-		     "float",
-		     "friend",
-		     "inline",
-		     "int",
-		     "long",
-		     "mutable",
-		     "namespace",
-		     "private",
-		     "protected",
-		     "public",
-		     "register",
-		     "short",
-		     "signed",
-		     "sizeof",
-		     "static",
-		     "static_cast",
-		     "struct",
-		     "template",
-		     "typedef",
-		     "typename",
-		     "union",
-		     "unsigned",
-		     "virtual",
-		     "void",
-		     "volatile"
-		   };
-
-
-//
-// 'compare_keywords()' - Compare two keywords...
-//
-
-extern "C" {
-  int
-  compare_keywords(const void *a,
-                   const void *b) {
-    return (strcmp(*((const char **)a), *((const char **)b)));
-  }
-}
-
-//
-// 'style_parse()' - Parse text and produce style data.
-//
-
-void
-style_parse(const char *text,
-            char       *style,
-	    int        length) {
-  char	     current;
-  int	     col;
-  int	     last;
-  char	     buf[255],
-             *bufptr;
-  const char *temp;
-
-  // Style letters:
-  //
-  // A - Plain
-  // B - Line comments
-  // C - Block comments
-  // D - Strings
-  // E - Directives
-  // F - Types
-  // G - Keywords
-
-  for (current = *style, col = 0, last = 0; length > 0; length --, text ++) {
-    if (current == 'B' || current == 'F' || current == 'G') current = 'A';
-    if (current == 'A') {
-      // Check for directives, comments, strings, and keywords...
-      if (col == 0 && *text == '#') {
-        // Set style to directive
-        current = 'E';
-      } else if (strncmp(text, "//", 2) == 0) {
-        current = 'B';
-	for (; length > 0 && *text != '\n'; length --, text ++) *style++ = 'B';
-
-        if (length == 0) break;
-      } else if (strncmp(text, "/*", 2) == 0) {
-        current = 'C';
-      } else if (strncmp(text, "\\\"", 2) == 0) {
-        // Quoted quote...
-	*style++ = current;
-	*style++ = current;
-	text ++;
-	length --;
-	col += 2;
-	continue;
-      } else if (*text == '\"') {
-        current = 'D';
-      } else if (!last && (islower(*text) || *text == '_')) {
-        // Might be a keyword...
-	for (temp = text, bufptr = buf;
-	     (islower(*temp) || *temp == '_') && bufptr < (buf + sizeof(buf) - 1);
-	     *bufptr++ = *temp++);
-
-        if (!islower(*temp) && *temp != '_') {
-	  *bufptr = '\0';
-
-          bufptr = buf;
-
-	  if (bsearch(&bufptr, code_types,
-	              sizeof(code_types) / sizeof(code_types[0]),
-		      sizeof(code_types[0]), compare_keywords)) {
-	    while (text < temp) {
-	      *style++ = 'F';
-	      text ++;
-	      length --;
-	      col ++;
-	    }
-
-	    text --;
-	    length ++;
-	    last = 1;
-	    continue;
-	  } else if (bsearch(&bufptr, code_keywords,
-	                     sizeof(code_keywords) / sizeof(code_keywords[0]),
-		             sizeof(code_keywords[0]), compare_keywords)) {
-	    while (text < temp) {
-	      *style++ = 'G';
-	      text ++;
-	      length --;
-	      col ++;
-	    }
-
-	    text --;
-	    length ++;
-	    last = 1;
-	    continue;
-	  }
-	}
-      }
-    } else if (current == 'C' && strncmp(text, "*/", 2) == 0) {
-      // Close a C comment...
-      *style++ = current;
-      *style++ = current;
-      text ++;
-      length --;
-      current = 'A';
-      col += 2;
-      continue;
-    } else if (current == 'D') {
-      // Continuing in string...
-      if (strncmp(text, "\\\"", 2) == 0) {
-        // Quoted end quote...
-	*style++ = current;
-	*style++ = current;
-	text ++;
-	length --;
-	col += 2;
-	continue;
-      } else if (*text == '\"') {
-        // End quote...
-	*style++ = current;
-	col ++;
-	current = 'A';
-	continue;
-      }
-    }
-
-    // Copy style info...
-    if (current == 'A' && (*text == '{' || *text == '}')) *style++ = 'G';
-    else *style++ = current;
-    col ++;
-
-    last = isalnum(*text) || *text == '_' || *text == '.';
-
-    if (*text == '\n') {
-      // Reset column and possibly reset the style
-      col = 0;
-      if (current == 'B' || current == 'E') current = 'A';
-    }
-  }
-}
-
-
-//
-// 'style_init()' - Initialize the style buffer...
-//
-
-void
-style_init(void) {
-  char *style = new char[textbuf->length() + 1];
-  char *text = textbuf->text();
-  
-
-  memset(style, 'A', textbuf->length());
-  style[textbuf->length()] = '\0';
-
-  if (!stylebuf) stylebuf = new Fl_Text_Buffer(textbuf->length());
-
-  style_parse(text, style, textbuf->length());
-
-  stylebuf->text(style);
-  delete[] style;
-  free(text);
-}
-
-
-//
-// 'style_unfinished_cb()' - Update unfinished styles.
-//
-
-void
-style_unfinished_cb(int, void*) {
-}
-
-
-//
-// 'style_update()' - Update the style buffer...
-//
-
-void
-style_update(int        pos,		// I - Position of update
-             int        nInserted,	// I - Number of inserted chars
-	     int        nDeleted,	// I - Number of deleted chars
-             int        /*nRestyled*/,	// I - Number of restyled chars
-	     const char * /*deletedText*/,// I - Text that was deleted
-             void       *cbArg) {	// I - Callback data
-  int	start,				// Start of text
-	end;				// End of text
-  char	last,				// Last style on line
-	*style,				// Style data
-	*text;				// Text data
-
-
-  // If this is just a selection change, just unselect the style buffer...
-  if (nInserted == 0 && nDeleted == 0) {
-    stylebuf->unselect();
-    return;
-  }
-
-  // Track changes in the text buffer...
-  if (nInserted > 0) {
-    // Insert characters into the style buffer...
-    style = new char[nInserted + 1];
-    memset(style, 'A', nInserted);
-    style[nInserted] = '\0';
-
-    stylebuf->replace(pos, pos + nDeleted, style);
-    delete[] style;
-  } else {
-    // Just delete characters in the style buffer...
-    stylebuf->remove(pos, pos + nDeleted);
-  }
-
-  // Select the area that was just updated to avoid unnecessary
-  // callbacks...
-  stylebuf->select(pos, pos + nInserted - nDeleted);
-
-  // Re-parse the changed region; we do this by parsing from the
-  // beginning of the previous line of the changed region to the end of
-  // the line of the changed region...  Then we check the last
-  // style character and keep updating if we have a multi-line
-  // comment character...
-  start = textbuf->line_start(pos);
-//  if (start > 0) start = textbuf->line_start(start - 1);
-  end   = textbuf->line_end(pos + nInserted);
-  text  = textbuf->text_range(start, end);
-  style = stylebuf->text_range(start, end);
-  if (start==end)
-    last = 0;
-  else
-    last  = style[end - start - 1];
-
-//  printf("start = %d, end = %d, text = \"%s\", style = \"%s\", last='%c'...\n",
-//         start, end, text, style, last);
-
-  style_parse(text, style, end - start);
-
-//  printf("new style = \"%s\", new last='%c'...\n", 
-//         style, style[end - start - 1]);
-
-  stylebuf->replace(start, end, style);
-  ((Fl_Text_Editor *)cbArg)->redisplay_range(start, end);
-
-  if (start==end || last != style[end - start - 1]) {
-//    printf("Recalculate the rest of the buffer style\n");
-    // Either the user deleted some text, or the last character 
-    // on the line changed styles, so reparse the
-    // remainder of the buffer...
-    free(text);
-    free(style);
-
-    end   = textbuf->length();
-    text  = textbuf->text_range(start, end);
-    style = stylebuf->text_range(start, end);
-
-    style_parse(text, style, end - start);
-
-    stylebuf->replace(start, end, style);
-    ((Fl_Text_Editor *)cbArg)->redisplay_range(start, end);
-  }
-
-  free(text);
-  free(style);
-}
-
-
 // Editor window functions and class...
 void save_cb();
 void saveas_cb();
@@ -425,6 +98,7 @@ void find2_cb(Fl_Widget*, void*);
 void replall_cb(Fl_Widget*, void*);
 void replace2_cb(Fl_Widget*, void*);
 void replcan_cb(Fl_Widget*, void*);
+
 
 class EditorWindow : public Fl_Double_Window {
   public:
@@ -437,6 +111,14 @@ class EditorWindow : public Fl_Double_Window {
     Fl_Button          *replace_all;
     Fl_Return_Button   *replace_next;
     Fl_Button          *replace_cancel;
+
+#ifdef ENA_LINEWRAP
+    int			wrap_mode;
+#endif // ENA_LINEWRAP
+
+#ifdef ENA_LINENUMS
+    int			line_numbers;
+#endif // ENA_LINENUMS
 
     Fl_Text_Editor     *editor;
     char               search[256];
@@ -462,6 +144,14 @@ EditorWindow::EditorWindow(int w, int h, const char* t) : Fl_Double_Window(w, h,
   replace_dlg->set_non_modal();
   editor = 0;
   *search = (char)0;
+
+#ifdef ENA_LINEWRAP
+  wrap_mode = 0;
+#endif // ENA_LINEWRAP
+
+#ifdef ENA_LINENUMS
+  line_numbers = 0;
+#endif // ENA_LINENUMS
 }
 
 EditorWindow::~EditorWindow() {
@@ -522,6 +212,36 @@ void cut_cb(Fl_Widget*, void* v) {
 void delete_cb(Fl_Widget*, void*) {
   textbuf->remove_selection();
 }
+
+#ifdef ENA_LINEWRAP
+void wordwrap_cb(Fl_Widget *w, void* v) {
+  EditorWindow* e = (EditorWindow*)v;
+  Fl_Menu_Bar* m = (Fl_Menu_Bar*)w;
+  const Fl_Menu_Item* i = m->mvalue();
+  if ( i->value() )
+    e->editor->wrap_mode(Fl_Text_Display::WRAP_AT_BOUNDS, 0);
+  else
+    e->editor->wrap_mode(Fl_Text_Display::WRAP_NONE, 0);
+  e->wrap_mode = (i->value()?1:0);
+  e->redraw();
+}
+#endif // ENA_LINEWRAP
+
+#ifdef ENA_LINENUMS
+void linenumbers_cb(Fl_Widget *w, void* v) {
+  EditorWindow* e = (EditorWindow*)v;
+  Fl_Menu_Bar* m = (Fl_Menu_Bar*)w;
+  const Fl_Menu_Item* i = m->mvalue();
+  if ( i->value() ) {
+    e->editor->linenumber_width(line_num_width);	// enable
+    e->editor->linenumber_size(e->editor->textsize());
+  } else {
+    e->editor->linenumber_width(0);	// disable
+  }
+  e->line_numbers = (i->value()?1:0);
+  e->redraw();
+}
+#endif // ENA_LINENUMS
 
 void find_cb(Fl_Widget* w, void* v) {
   EditorWindow* e = (EditorWindow*)v;
@@ -727,7 +447,7 @@ void view_cb(Fl_Widget*, void*) {
 }
 
 Fl_Menu_Item menuitems[] = {
-  { "&File",              0, 0, 0, FL_SUBMENU },
+    { "&File",              0, 0, 0, FL_SUBMENU },
     { "&New File",        0, (Fl_Callback *)new_cb },
     { "&Open File...",    FL_CTRL + 'o', (Fl_Callback *)open_cb },
     { "&Insert File...",  FL_CTRL + 'i', (Fl_Callback *)insert_cb, 0, FL_MENU_DIVIDER },
@@ -743,6 +463,15 @@ Fl_Menu_Item menuitems[] = {
     { "&Copy",       FL_CTRL + 'c', (Fl_Callback *)copy_cb },
     { "&Paste",      FL_CTRL + 'v', (Fl_Callback *)paste_cb },
     { "&Delete",     0, (Fl_Callback *)delete_cb },
+
+#ifdef ENA_LINENUMS
+    { "Line &Numbers ",   FL_COMMAND + 'n', (Fl_Callback *)linenumbers_cb, 0, FL_MENU_TOGGLE },
+#endif // ENA_LINENUMS
+
+#ifdef ENA_LINEWRAP
+    { "Word Wrap",      FL_COMMAND + 'l', (Fl_Callback *)wordwrap_cb, 0, FL_MENU_TOGGLE },
+#endif // ENA_LINEWRAP
+
     { 0 },
 
   { "&Search", 0, 0, 0, FL_SUBMENU },
@@ -750,6 +479,10 @@ Fl_Menu_Item menuitems[] = {
     { "F&ind Again",    FL_CTRL + 'g', find2_cb },
     { "&Replace...",    FL_CTRL + 'r', replace_cb },
     { "Re&place Again", FL_CTRL + 't', replace2_cb },
+    { 0 },
+
+  { "&Version", 0, 0, 0, FL_SUBMENU },
+    { Version },
     { 0 },
 
   { 0 }
@@ -762,15 +495,11 @@ Fl_Window* new_view() {
     m->copy(menuitems, w);
     w->editor = new Fl_Text_Editor(0, 30, 660, 370);
     w->editor->buffer(textbuf);
-    w->editor->highlight_data(stylebuf, styletable,
-                              sizeof(styletable) / sizeof(styletable[0]),
-			      'A', style_unfinished_cb, 0);
     w->editor->textfont(FL_COURIER);
   w->end();
   w->resizable(w->editor);
   w->callback((Fl_Callback *)close_cb, w);
 
-  textbuf->add_modify_callback(style_update, w->editor);
   textbuf->add_modify_callback(changed_cb, w);
   textbuf->call_modify_callbacks();
   num_windows++;
@@ -778,8 +507,12 @@ Fl_Window* new_view() {
 }
 
 int main(int argc, char **argv) {
+
+#ifdef DIS_DNDTEXT
+  Fl::dnd_text_ops(false);
+#endif // DIS_DNDTEXT
+
   textbuf = new Fl_Text_Buffer;
-  style_init();
 
   Fl_Window* window = new_view();
 


### PR DESCRIPTION
// Ver 0.2 1/21/2025
// Changed by: Rich for Tinycore Linux.
// Removed syntax highlighting.
// Disabled "drag and drop text". You can re-enable it with  ~/.Xdefaults:
//        fltk*dndTextOps: true
// Added version number to source.
// Added Version menu entry.
// Added line number and line wrap code lifted from a later version of this program.
// I added these options in preprocessor directives:
//     Uncomment #define DIS_DNDTEXT to disable drag and drop text.
//     Uncomment #define ENA_LINEWRAP to enable line wrapping in Edit menu.
//     Uncomment #define ENA_LINENUMS to enable line numbers in Edit menu.
//
// --------------------------- End Log ---------------------------- //