### PR TITLE
changed (unsigned)sloc to (long unsigned)sloc.

### DIFF
--- a/apps/apps.cxx
+++ b/apps/apps.cxx
@@ -1139,7 +1139,7 @@ int main(int argc, char **argv) {
   proc_cmdline.close();
   target_boot_option = "lst=";
   int sloc = cmdline.find(target_boot_option);
-  if ( (unsigned)sloc == string::npos ) {
+  if ( (long unsigned)sloc == string::npos ) {
      onbootName = "onboot.lst";
   } else {
      int eloc = cmdline.find(" ",sloc);

--- a/apps/apps.fl
+++ b/apps/apps.fl
@@ -1075,7 +1075,7 @@ getline(proc_cmdline, cmdline);
 proc_cmdline.close();
 target_boot_option = "lst=";
 int sloc = cmdline.find(target_boot_option);
-if ( (unsigned)sloc == string::npos ) {
+if ( (long unsigned)sloc == string::npos ) {
    onbootName = "onboot.lst";
 } else {
    int eloc = cmdline.find(" ",sloc);
@@ -1103,7 +1103,8 @@ if (writest.fail()) {
    exit(1);
 }
 writest.close();
-unlink(testfile.c_str());} {}
+unlink(testfile.c_str());} {selected
+  }
   Fl_Window window {
     label {Apps: Regular Applications (tcz)}
     user_data {"quit"}
@@ -1474,7 +1475,7 @@ outURI->value(mirror.c_str());}
         }
       }
       Fl_Browser brwResults {
-        callback brwResultsCB selected
+        callback brwResultsCB
         xywh {210 52 475 325} type Hold textfont 4
         code0 {brwResults->textsize(10);}
       }


### PR DESCRIPTION
int and long int are 4 and 4 bytes in x86.

int and long int are 4 and 8 bytes in x86_64. This caused an incorrect result when they were compared
for equality.

